### PR TITLE
lodash version bump

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
         "convert-source-map": "^1.1.0",
         "debug": "^3.1.0",
         "json5": "^0.5.0",
-        "lodash": "^4.17.10",
+        "lodash": "^4.17.13",
         "resolve": "^1.3.2",
         "semver": "^5.4.1",
         "source-map": "^0.5.0"
@@ -47,7 +47,7 @@
       "requires": {
         "@babel/types": "^7.4.4",
         "jsesc": "^2.5.1",
-        "lodash": "^4.17.11",
+        "lodash": "^4.17.13",
         "source-map": "^0.5.0",
         "trim-right": "^1.0.1"
       },
@@ -102,7 +102,7 @@
       "requires": {
         "@babel/helper-function-name": "^7.1.0",
         "@babel/types": "^7.4.4",
-        "lodash": "^4.17.11"
+        "lodash": "^4.17.13"
       }
     },
     "@babel/helper-explode-assignable-expression": {
@@ -166,7 +166,7 @@
         "@babel/helper-split-export-declaration": "^7.4.4",
         "@babel/template": "^7.4.4",
         "@babel/types": "^7.4.4",
-        "lodash": "^4.17.11"
+        "lodash": "^4.17.13"
       }
     },
     "@babel/helper-optimise-call-expression": {
@@ -187,7 +187,7 @@
       "resolved": "https://registry.npmjs.org/@babel/helper-regex/-/helper-regex-7.4.4.tgz",
       "integrity": "sha512-Y5nuB/kESmR3tKjU8Nkn1wMGEx1tjJX076HBMeL3XLQCu6vA/YRzuTW0bbb+qRnXvQGn+d6Rx953yffl8vEy7Q==",
       "requires": {
-        "lodash": "^4.17.11"
+        "lodash": "^4.17.13"
       }
     },
     "@babel/helper-remap-async-to-generator": {
@@ -414,7 +414,7 @@
       "integrity": "sha512-jkTUyWZcTrwxu5DD4rWz6rDB5Cjdmgz6z7M7RLXOJyCUkFBawssDGcGh8M/0FTSB87avyJI1HsTwUXp9nKA1PA==",
       "requires": {
         "@babel/helper-plugin-utils": "^7.0.0",
-        "lodash": "^4.17.11"
+        "lodash": "^4.17.13"
       }
     },
     "@babel/plugin-transform-classes": {
@@ -771,7 +771,7 @@
         "@babel/types": "^7.4.4",
         "debug": "^4.1.0",
         "globals": "^11.1.0",
-        "lodash": "^4.17.11"
+        "lodash": "^4.17.13"
       },
       "dependencies": {
         "debug": {
@@ -790,7 +790,7 @@
       "integrity": "sha512-dOllgYdnEFOebhkKCjzSVFqw/PmmB8pH6RGOWkY4GsboQNd47b1fBThBSwlHAq9alF9vc1M3+6oqR47R50L0tQ==",
       "requires": {
         "esutils": "^2.0.2",
-        "lodash": "^4.17.11",
+        "lodash": "^4.17.13",
         "to-fast-properties": "^2.0.0"
       }
     },
@@ -1322,7 +1322,7 @@
         "bluebird": "^3.5.0",
         "del": "^3.0.0",
         "find-cache-dir": "^1.0.0",
-        "lodash": "^4.17.4",
+        "lodash": "^4.17.13",
         "make-dir": "^1.0.0",
         "memory-fs": "^0.4.1",
         "read-pkg": "^2.0.0",
@@ -1453,7 +1453,7 @@
       "requires": {
         "babel-runtime": "^6.26.0",
         "esutils": "^2.0.2",
-        "lodash": "^4.17.4",
+        "lodash": "^4.17.13",
         "to-fast-properties": "^1.0.3"
       },
       "dependencies": {
@@ -3936,7 +3936,7 @@
       }
     },
     "lodash": {
-      "version": "4.17.11",
+      "version": "4.17.13",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
       "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
     },
@@ -5068,7 +5068,7 @@
       "integrity": "sha512-xDr0jhgt/o26atftXxTVsepz+QYZI2GNKBYpxtLvYgwffLUm18a9n562reUJAHvuwKsy2v+qMlK5HyjFtSW0mg==",
       "dev": true,
       "requires": {
-        "lodash": "^4.17.4",
+        "lodash": "^4.17.13",
         "prop-types": "^15.5.8"
       }
     },
@@ -6876,7 +6876,7 @@
       "resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-4.2.1.tgz",
       "integrity": "sha512-4p8WQyS98bUJcCvFMbdGZyZmsKuWjWVnVHnAS3FFg0HDaRVrPbkivx2RYCre8UiemD67RsiFFLfn4JhLAin8Vw==",
       "requires": {
-        "lodash": "^4.17.5"
+        "lodash": "^4.17.13"
       }
     },
     "webpack-sources": {


### PR DESCRIPTION
## Overview

This PR mitigates a vulnerability with old version of lodash which our project uses as a dependency by updating the version of lodash which is not subject to the threat.

<img width="700" alt="Screen Shot 2019-07-13 at 2 41 46 PM" src="https://user-images.githubusercontent.com/28017034/61176827-7345e900-a57c-11e9-97eb-34506e988668.png">

## Review

@AdCLeung @arshiannafi @Eli-CB 