### PR TITLE
Update the width of Contact page's card

### DIFF
--- a/pages/contact.js
+++ b/pages/contact.js
@@ -53,41 +53,39 @@ class Contact extends Component {
                             <Card>
                                 <Card.Body>
                                     <Card.Title>Contact Us</Card.Title>
-                                    <Card.Text>
-                                        <Form action="https://formspree.io/brakessupreme@gmail.com" method="POST" >
-                                            <Form.Group controlId="nameInput">
-                                                <Form.Label>Name</Form.Label>
-                                                <Form.Control
-                                                    name="name"
-                                                    type="text"
-                                                    placeholder="John Smith"
-                                                    required
-                                                />
-                                            </Form.Group>
-                                            <Form.Group controlId="emailInput">
-                                                <Form.Label>Email address</Form.Label>
-                                                <Form.Control
-                                                    name="email"
-                                                    type="email"
-                                                    placeholder="john.smith@mail.me"
-                                                    required
-                                                />
-                                            </Form.Group>
-                                            <Form.Group controlId="messageTextarea">
-                                                <Form.Label>Message</Form.Label>
-                                                <Form.Control
-                                                    name="message"
-                                                    as="textarea"
-                                                    rows="5"
-                                                    placeholder="Go ahead, we're listening..."
-                                                    required
-                                                />
-                                            </Form.Group>
-                                            <Button variant="outline-info" type="submit">
-                                                Submit
-                                            </Button>
-                                        </Form>
-                                    </Card.Text>
+                                    <Form action="https://formspree.io/brakessupreme@gmail.com" method="POST" >
+                                        <Form.Group controlId="nameInput">
+                                            <Form.Label>Name</Form.Label>
+                                            <Form.Control
+                                                name="name"
+                                                type="text"
+                                                placeholder="John Smith"
+                                                required
+                                            />
+                                        </Form.Group>
+                                        <Form.Group controlId="emailInput">
+                                            <Form.Label>Email address</Form.Label>
+                                            <Form.Control
+                                                name="email"
+                                                type="email"
+                                                placeholder="john.smith@mail.me"
+                                                required
+                                            />
+                                        </Form.Group>
+                                        <Form.Group controlId="messageTextarea">
+                                            <Form.Label>Message</Form.Label>
+                                            <Form.Control
+                                                name="message"
+                                                as="textarea"
+                                                rows="5"
+                                                placeholder="Go ahead, we're listening..."
+                                                required
+                                            />
+                                        </Form.Group>
+                                        <Button variant="outline-info" type="submit">
+                                            Submit
+                                        </Button>
+                                    </Form>
                                 </Card.Body>
                             </Card>
                         </Col>

--- a/pages/contact.js
+++ b/pages/contact.js
@@ -49,7 +49,7 @@ class Contact extends Component {
 
                 <Container className="my-3">
                     <Row className="justify-content-center">
-                        <Col md={6}>
+                        <Col>
                             <Card>
                                 <Card.Body>
                                     <Card.Title>Contact Us</Card.Title>


### PR DESCRIPTION
### Overview

This PR:
- Update the width of the card (bounding box) in the Contact's page for laptop and larger screens. Mobile view remains unchanged. Screenshots attached.
- Fixes an error in the console. Error: `<div>` cannot appear as a child of `<p>`

### Screenshots

![image](https://user-images.githubusercontent.com/19654498/61574161-4019c300-aa70-11e9-82d9-3fd95f9b72b0.png)

![image](https://user-images.githubusercontent.com/19654498/61574190-bdddce80-aa70-11e9-90fe-918ccac06dd4.png)
