### PR TITLE
change signup button to view dashboard if authed

### DIFF
--- a/pages/index.js
+++ b/pages/index.js
@@ -8,6 +8,7 @@ import Container from 'react-bootstrap/Container';
 import Row from 'react-bootstrap/Row';
 import Col from 'react-bootstrap/Col';
 import Card from 'react-bootstrap/Card';
+import Router from 'next/router';
 
 const host = 'http://localhost';
 const port = 3001;
@@ -79,7 +80,12 @@ class Index extends Component {
                     <div className="p-5"></div>
                     <Row className="text-center">
                         <Col className="mt-3 mb-5">
-                            <button className="btn btn-light btn-lg" onClick={() => this.setState({ showSignupModal: true })}>Sign Up Now!</button>
+                            {!isAuthenticated && (
+                                <button className="btn btn-light btn-lg" onClick={() => this.setState({ showSignupModal: true })}>Sign Up Now!</button>
+                            )}
+                            {isAuthenticated && (
+                                <button className="btn btn-light btn-lg" onClick={() => Router.push({ pathname: '/dashboard' })}>View Your Dashboard</button>
+                            )}
                         </Col>
                     </Row>
                     <div className="p-5"></div>


### PR DESCRIPTION
## Overview

This PR changes the main button on homepage to not show `sign up now` option once user is already authed.

## Screenshots

if in authed state, clicking the button will redirect them to the dashboard page:

<img width="1279" alt="Screen Shot 2019-07-19 at 10 26 52 PM" src="https://user-images.githubusercontent.com/28017034/61574422-63df0800-aa74-11e9-80c3-6531903e4d5d.png">

if in unauthed state:

<img width="1279" alt="Screen Shot 2019-07-19 at 10 27 02 PM" src="https://user-images.githubusercontent.com/28017034/61574425-70fbf700-aa74-11e9-82c9-8b21bf83aaff.png">
